### PR TITLE
Develop

### DIFF
--- a/MDWamp/src/MDWampTransports/MDWampTransportWebSocket.h
+++ b/MDWamp/src/MDWampTransports/MDWampTransportWebSocket.h
@@ -39,6 +39,19 @@ FOUNDATION_EXPORT NSString *const kMDWampProtocolWamp2msgpack;
 - (id)initWithServer:(NSURL *)request protocolVersions:(NSArray *)protocols;
 
 /**
+ *  Default initializer
+ *  By restricting the array of protocol versions we force to use a given protocol
+ *  they are in the form of wamp, wamp.2.json, wamp.2.msgpack
+ *
+ *  @param request   request representing a server
+ *  
+ *  @param allowUntrustedSSLCertificates whether or not MDWamp shoudl care for SSL certificates
+ *
+ *  @return intsance of the transport
+ */
+- (id)initWithServer:(NSURL *)request protocolVersions:(NSArray *)protocols allowUntrustedSSLCertificates:(BOOL)allowsUntrustedSSLCertificates;
+
+/**
  * Request Cookies
  * Sets the request cookies
  *

--- a/MDWamp/src/MDWampTransports/MDWampTransportWebSocket.m
+++ b/MDWamp/src/MDWampTransports/MDWampTransportWebSocket.m
@@ -39,12 +39,30 @@ NSString *const kMDWampProtocolWamp2msgpack = @"wamp.2.msgpack";
 - (id)initWithServer:(NSURL *)request protocolVersions:(NSArray *)protocols
 {
     self = [super init];
-    self.allowsUntrustedSSLCertificates = NO;
+    
     if (self) {
         NSAssert([protocols count] > 0, @"Specify a valid WAMP protocol");
         
         NSAssert(([protocols containsObject:kMDWampProtocolWamp2json]
                   ||[protocols containsObject:kMDWampProtocolWamp2msgpack]), @"No valid WAMP protocol found");
+        self.request = request;
+        self.protocols = protocols;
+        
+    }
+    return self;
+}
+
+
+- (id)initWithServer:(NSURL *)request protocolVersions:(NSArray *)protocols allowUntrustedSSLCertificates:(BOOL)allowsUntrustedSSLCertificates
+{
+    self = [super init];
+    
+    if (self) {
+        NSAssert([protocols count] > 0, @"Specify a valid WAMP protocol");
+        
+        NSAssert(([protocols containsObject:kMDWampProtocolWamp2json]
+                  ||[protocols containsObject:kMDWampProtocolWamp2msgpack]), @"No valid WAMP protocol found");
+        self.allowsUntrustedSSLCertificates = allowsUntrustedSSLCertificates;
         self.request = request;
         self.protocols = protocols;
         

--- a/MDWamp/src/MDWampTransports/MDWampTransportWebSocket.m
+++ b/MDWamp/src/MDWampTransports/MDWampTransportWebSocket.m
@@ -31,6 +31,7 @@ NSString *const kMDWampProtocolWamp2msgpack = @"wamp.2.msgpack";
 @property (nonatomic, strong) SRWebSocket *socket;
 @property (nonatomic, strong) NSArray *protocols;
 @property (nonatomic, strong) NSURL *request;
+@property (nonatomic) BOOL allowsUntrustedSSLCertificates;
 @end
 
 @implementation MDWampTransportWebSocket 
@@ -38,6 +39,7 @@ NSString *const kMDWampProtocolWamp2msgpack = @"wamp.2.msgpack";
 - (id)initWithServer:(NSURL *)request protocolVersions:(NSArray *)protocols
 {
     self = [super init];
+    self.allowsUntrustedSSLCertificates = NO;
     if (self) {
         NSAssert([protocols count] > 0, @"Specify a valid WAMP protocol");
         
@@ -56,8 +58,7 @@ NSString *const kMDWampProtocolWamp2msgpack = @"wamp.2.msgpack";
 
 - (void) open
 {
-    NSLog(@"hello allow untrusted stuff");
-    self.socket = [[SRWebSocket alloc] initWithURL:_request protocols:_protocols allowsUntrustedSSLCertificates:YES];
+    self.socket = [[SRWebSocket alloc] initWithURL:_request protocols:_protocols allowsUntrustedSSLCertificates:self.allowsUntrustedSSLCertificates];
     [_socket setDelegate:self];
     [_socket open];
 }
@@ -67,6 +68,7 @@ NSString *const kMDWampProtocolWamp2msgpack = @"wamp.2.msgpack";
     [_socket close];
     self.socket = nil;
 }
+
 
 - (BOOL) isConnected
 {

--- a/MDWamp/src/MDWampTransports/MDWampTransportWebSocket.m
+++ b/MDWamp/src/MDWampTransports/MDWampTransportWebSocket.m
@@ -56,7 +56,8 @@ NSString *const kMDWampProtocolWamp2msgpack = @"wamp.2.msgpack";
 
 - (void) open
 {
-    self.socket = [[SRWebSocket alloc] initWithURL:_request protocols:_protocols];
+    NSLog(@"hello allow untrusted stuff");
+    self.socket = [[SRWebSocket alloc] initWithURL:_request protocols:_protocols allowsUntrustedSSLCertificates:YES];
     [_socket setDelegate:self];
     [_socket open];
 }


### PR DESCRIPTION
I added an initializer to MDWampTransportWebSocket so that it's possible to accept all SSL certificates. This actually solves the issue #42 
It turns out that my app was using up file descriptors like crazy by reconnecting with MDWamp all the time because the SSL Handshake failed.
