### PR TITLE
clear the explicit session close flag

### DIFF
--- a/MDWamp/src/MDWamp.m
+++ b/MDWamp/src/MDWamp.m
@@ -123,6 +123,8 @@
 
 - (void) connect
 {
+    _explicitSessionClose = NO;
+
     [self.transport open];
 }
 


### PR DESCRIPTION
I was setting up my iOS app to automatically close the session when the app backgrounds and then open it back up when the app foregrounds.  I was also testing auto reconnection logic by starting and stopping the crossbar.  I noticed that eventually I wasn't getting a callback when the session was closed by stopping the router.

After debugging, I realized it was happening because there is no logic that will eventually clear the "_explicitSessionClose" flag once it has been set.  This PR clears it when connect it called to resolve the issue.