### PR TITLE
NSNull response handler

### DIFF
--- a/MDWamp/src/MDWampMessages/MDWampError.m
+++ b/MDWamp/src/MDWampMessages/MDWampError.m
@@ -57,7 +57,7 @@
 - (NSError *) makeError
 {
     NSDictionary *info;
-    if (self.details) {
+	if (self.details && [self.details isKindOfClass:[NSDictionary class]]) {
         info = [self.details mutableCopy];
         [(NSMutableDictionary*)info setObject:self.error forKey:NSLocalizedDescriptionKey];
         if (self.arguments) {


### PR DESCRIPTION
Getting NSNull as error response crashes MDWamp and the application. I've added the check for verifying `self.details` property